### PR TITLE
Moving bearing back to its own frame (fix pr#7321)

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -916,12 +916,13 @@ void Screen::setFrames(FrameFocus focus)
     fsi.positions.nodelist_distance = numframes;
     normalFrames[numframes++] = graphics::NodeListRenderer::drawDistanceScreen;
     indicatorIcons.push_back(icon_distance);
-
+#endif
+#if HAS_GPS
     fsi.positions.nodelist_bearings = numframes;
     normalFrames[numframes++] = graphics::NodeListRenderer::drawNodeListWithCompasses;
     indicatorIcons.push_back(icon_list);
-#endif
-#if HAS_GPS
+
+    // adding new BRC page 
     fsi.positions.nodelist_brc = numframes;
     normalFrames[numframes++] = graphics::NodeListRenderer::drawBRCList;
     indicatorIcons.push_back(icon_bm);

--- a/src/graphics/draw/NodeListRenderer.cpp
+++ b/src/graphics/draw/NodeListRenderer.cpp
@@ -545,31 +545,8 @@ void drawDynamicNodeListScreen(OLEDDisplay *display, OLEDDisplayUiState *state, 
 
     // Render screen based on currentMode
     const char *title = getCurrentModeTitle(display->getWidth());
+    drawNodeListScreen(display, state, x, y, title, drawEntryDynamic);
 
-    if (currentMode == MODE_BEARING) {
-        float heading = 0;
-        bool validHeading = false;
-        auto ourNode = nodeDB->getMeshNode(nodeDB->getNodeNum());
-        double lat = DegD(ourNode->position.latitude_i);
-        double lon = DegD(ourNode->position.longitude_i);
-
-        if (uiconfig.compass_mode != meshtastic_CompassMode_FREEZE_HEADING) {
-            if (screen->hasHeading()) {
-                heading = screen->getHeading(); // degrees
-                validHeading = true;
-            } else {
-                heading = screen->estimatedHeading(lat, lon);
-                validHeading = !isnan(heading);
-            }
-            if (!validHeading) {
-                lastRenderedMode = MODE_COUNT;
-                return;
-            }
-        }
-        drawNodeListScreen(display, state, x, y, title, drawEntryCompass, drawCompassArrow, heading, lat, lon);
-    } else {
-        drawNodeListScreen(display, state, x, y, title, drawEntryDynamic);
-    }
 
     // Track the last mode to avoid reinitializing modeStartTime
     lastRenderedMode = currentMode;


### PR DESCRIPTION
Hi @tschundler,

Here is a proposed implementation of the additive change discussed in PR #7321, based on feedback from @Xaositek.

This commit restores the original separate Bearings screen and cleanly adds the BRC screen, resolving the sustainability concerns. This should make the PR ready for final review.

Thanks!
